### PR TITLE
Allow pass-through of prompt= parameters when starting OAuth flows

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -87,6 +87,9 @@ func (p *provider) handleStart(w http.ResponseWriter, r *http.Request) {
 	if hd := r.URL.Query().Get("hd"); hd != "" {
 		opts = append(opts, oauth2.SetAuthURLParam("hd", hd))
 	}
+	if prompt := r.URL.Query().Get("prompt"); prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
 
 	http.Redirect(w, r, p.config(r).AuthCodeURL(tr.Nonce, opts...), http.StatusFound)
 }


### PR DESCRIPTION
Required to initiate re-auth with Google per
https://developers.google.com/identity/openid-connect/openid-connect#re-consent
