### PR TITLE
Initial Vanta provider support (#11)

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ curl \
 
 ### Refreshing access tokens
 
-Some identity providers issue access tokens that expire quickly along with refresh tokens that can be used to fetch new access tokens. To fetch a new access token, send a request to `https://<ssokenizer-url>/<provider-name>/refresh` via tokenizer. Include the sealed token in the `Proxy-Tokenizer` header, including a `st=refresh` parameter in the header. The response body will contain the new token, sealed for use with tokenizer.
+Some identity providers issue access tokens that expire quickly along with refresh tokens that can be used to fetch new access tokens. To fetch a new access token, send a request to `https://<ssokenizer-url>/<provider-name>/refresh` via tokenizer. Include the sealed token in the `Proxy-Tokenizer` header, including a `st=refresh` parameter in the header. The response body will contain the new token, sealed for use with tokenizer and the Cache-Control header will contain the seconds until the token expires.
 
 The following demonstrates how you might refresh a token using cURL:
 

--- a/cmd/ssokenizer/main.go
+++ b/cmd/ssokenizer/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/superfly/ssokenizer"
 	"github.com/superfly/ssokenizer/oauth2"
+	"github.com/superfly/ssokenizer/vanta"
 	"github.com/superfly/tokenizer"
 	xoauth2 "golang.org/x/oauth2"
 	"golang.org/x/oauth2/amazon"
@@ -171,6 +172,21 @@ type IdentityProviderConfig struct {
 
 func (c IdentityProviderConfig) providerConfig(name, returnURL string) (ssokenizer.ProviderConfig, error) {
 	switch c.Profile {
+	case "vanta":
+		return &vanta.Config{
+			Path: "/" + name,
+			Config: xoauth2.Config{
+				ClientID:     c.ClientID,
+				ClientSecret: c.ClientSecret,
+				Scopes:       c.Scopes,
+				Endpoint: xoauth2.Endpoint{
+					AuthURL:   "https://app.vanta.com/oauth/authorize",
+					TokenURL:  "https://api.vanta.com/oauth/token",
+					AuthStyle: xoauth2.AuthStyleInParams,
+				},
+			},
+			ForwardParams: []string{"source_id"},
+		}, nil
 	case "oauth":
 		return &oauth2.Config{
 			Path: "/" + name,
@@ -245,6 +261,7 @@ func (c IdentityProviderConfig) providerConfig(name, returnURL string) (ssokeniz
 				Scopes:       c.Scopes,
 				Endpoint:     google.Endpoint,
 			},
+			ForwardParams: []string{"hd"},
 		}, nil
 	case "heroku":
 		return &oauth2.Config{

--- a/ssokenizer.go
+++ b/ssokenizer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/superfly/tokenizer"
+	"golang.org/x/exp/maps"
 )
 
 type Server struct {
@@ -49,7 +50,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	provider, ok := s.providers[providerName]
 	if !ok {
-		GetLog(r).WithField("status", http.StatusNotFound).Info()
+		GetLog(r).WithFields(logrus.Fields{
+			"status":    http.StatusNotFound,
+			"providers": maps.Keys(s.providers),
+		}).Info()
+
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/vanta/vanta.go
+++ b/vanta/vanta.go
@@ -1,0 +1,110 @@
+package vanta
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/superfly/ssokenizer"
+	"github.com/superfly/ssokenizer/oauth2"
+	"github.com/superfly/tokenizer"
+	xoauth2 "golang.org/x/oauth2"
+)
+
+const (
+	invalidatePath = "/invalidate"
+	invalidateURL  = "https://api.vanta.com/v1/oauth/token/suspend"
+)
+
+type Config oauth2.Config
+
+func (c Config) Register(sealKey string, auth tokenizer.AuthConfig) (http.Handler, error) {
+	handler, err := oauth2.Config(c).Register(sealKey, auth)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSuffix(r.URL.Path, "/") != invalidatePath {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		var (
+			ctx = r.Context()
+			log = ssokenizer.GetLog(r)
+		)
+
+		accessToken, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if !ok {
+			log.WithField("status", http.StatusUnauthorized).
+				Info("invalidate: missing token")
+
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		tok, err := c.TokenSource(ctx, &xoauth2.Token{AccessToken: accessToken}).Token()
+		if err != nil {
+			log.WithField("status", http.StatusForbidden).
+				WithError(err).
+				Info("invalidate: failed to get token")
+
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		if typ := tok.Type(); typ != "Bearer" {
+			log.WithField("status", http.StatusForbidden).
+				WithField("type", typ).
+				WithError(err).
+				Info("invalidate: bad token type")
+
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		body, err := json.Marshal(map[string]string{
+			"token":         tok.AccessToken,
+			"client_id":     c.ClientID,
+			"client_secret": c.ClientSecret,
+		})
+		if err != nil {
+			log.WithField("status", http.StatusInternalServerError).
+				WithError(err).
+				Info("invalidate: marshal json")
+
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, invalidateURL, bytes.NewBuffer(body))
+		if err != nil {
+			log.WithField("status", http.StatusInternalServerError).
+				WithError(err).
+				Info("invalidate: make request")
+
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		client := http.Client{Timeout: 10 * time.Second}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			log.WithField("status", http.StatusServiceUnavailable).
+				WithError(err).
+				Info("invalidate: send request")
+
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		log.WithField("status", resp.Status).
+			Info("invalidate: success")
+	}), nil
+
+}


### PR DESCRIPTION
* Removed debug

* Removed debug

* Added invalidation route

* Inital roll out of added functionality for vanta

* Undoing local dev changes

* Totally minor doc update

* Minor tweak to (hopefully) keep state checking stable until replaced

* One more tidy-up

* Another unchecked split

* Cleanup more stale debug comments

* Sloppy cleanup is sloppy

* allow oauth config to specify params to forward on auth request

* move vanta-specific logic to its own package

* Fix botched conflict resolution

---------

Co-authored-by: btoews <benjamin.toews@gmail.com>