### PR TITLE
bump Dockerfile go version to match ed6d410 and pick up security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.23-alpine as builder
 
 WORKDIR /src/ssokenizer
 COPY . .


### PR DESCRIPTION
Go 1.21 base images are not being updated regularly it seems and make
container vuln scanning unhappy...
